### PR TITLE
Added docker-compose for basic development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-app
 db
 node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+version: "3.9"
+
+services:
+  strapi:
+    image: strapi/strapi
+    restart: always
+    environment:
+      - DATABASE_CLIENT=mysql
+      - DATABASE_HOST=strapidb
+      - DATABASE_PORT=3306
+      - DATABASE_NAME=strapi
+      - DATABASE_USERNAME=strapi
+      - DATABASE_PASSWORD=strapi
+    ports:
+      - 1337:1337
+    volumes:
+      - ./app:/srv/app
+    depends_on:
+      - strapidb
+
+  strapidb:
+    restart: always
+    image: mariadb:10.5.8-focal
+    restart: always
+    environment:
+      MYSQL_DATABASE: strapi
+      MYSQL_USER: strapi
+      MYSQL_PASSWORD: strapi
+      MYSQL_ROOT_PASSWORD: strapi
+    volumes:
+      - strapidb:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:5.6.1-apache
+    restart: always
+    ports:
+      - 80:80
+    environment:
+      WORDPRESS_DB_HOST: wordpressdb
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress:/var/www/html
+    depends_on:
+      - wordpressdb
+
+  wordpressdb:
+    restart: always
+    image: mariadb:10.5.8-focal
+    restart: always
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: wordpress
+    volumes:
+      - wordpressdb:/var/lib/mysql
+
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+
+volumes:
+  strapidb:
+    external: true
+  wordpress:
+    external: true
+  wordpressdb:
+    external: true


### PR DESCRIPTION
Here is a sample configuration to start working with Strapi, WordPress and phpMyAdmin.

Before using it execute the following Docker commands:

```
docker volume create wordpress
docker volume create wordpressdb
docker volume create strapidb
```